### PR TITLE
update trivy

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -17,11 +17,13 @@ jobs:
         with:
           scan-type: "fs"
           ignore-unfixed: true
+          exit-code: '1'
           format: "sarif"
           output: "trivy-results.sarif"
           severity: "UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL"
 
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v3
+        if: always()
         with:
           sarif_file: "trivy-results.sarif"


### PR DESCRIPTION
trivy workflow should fail when vulnerabilities are found
and the sarif file has to be sent to github security irrespective of the trivy run status