### PR TITLE
Handling non-updatable attributes while updating a resource

### DIFF
--- a/plugins/module_utils/module_executor.py
+++ b/plugins/module_utils/module_executor.py
@@ -361,11 +361,7 @@ class ModuleExecutor(object):
         if not self.module_result["diff_list"]:
             del self.module_result["diff_list"]
         if immutable_resource_module_params != []:
-            msg = (
-                "Cannot change value for the following non-updateable attributes %s"
-                % immutable_resource_module_params
-            )
-            return (False, msg)
+            return (False, immutable_resource_module_params)
 
         return (False, None) if diff_list else (True, None)
 
@@ -430,8 +426,12 @@ class ModuleExecutor(object):
                 self.resource_module_params["sitename"] = sitename
 
         else:
-            # Update only if resource is not identical (idempotent)
-            is_identical, msg = self.is_resource_identical()
+            # Update process will go through 2 iterations of is_resource_identical
+            # 1. First iteration will check if the resource is identical. If not, it will give the list of non-updatable attributes that exists
+            # in the user playbook. If non-updatable attributes are present, it will remove them from the module_params and update the resource
+            # 2. Second iteration will check if the resource is identical. If not, it will update the resource after ignoring the
+            # non-updatable resources
+            is_identical, immutable_keys_list = self.is_resource_identical()
             if is_identical:
                 log(
                     "INFO: Resource `%s:%s` exists and is identical. No change required."
@@ -453,7 +453,7 @@ class ModuleExecutor(object):
                         self.client, self.resource_name, self.resource_module_params
                     )
 
-                elif msg is None:
+                elif immutable_keys_list is None:
                     self.module_result["changed"] = True
                     log(
                         "INFO: Resource %s:%s exists and is different. Will be UPDATED."
@@ -465,28 +465,28 @@ class ModuleExecutor(object):
                     if not ok:
                         self.return_failure(err)
                 else:
-                    immutable_keys = [
-                        key for key in self.resource_module_params.keys()
-                        if key in NITRO_RESOURCE_MAP[self.resource_name]["immutable_keys"]
-                    ]
-                    for key in immutable_keys:
+                    for key in immutable_keys_list:
                         self.resource_module_params.pop(key)
 
-                    is_identical, msg1 = self.is_resource_identical()
+                    is_identical, _ = self.is_resource_identical()
 
-                    if is_identical and msg1 is None:
-                        self.module.warn(f"DEBUG: Resource not updated because - {msg}")
+                    if is_identical:
+                        msg = (
+                            f"Resource {self.resource_name}/{self.resource_id} not updated because user is trying to "
+                            f"update following non-updatable keys: {immutable_keys_list}"
+                        )
+                        self.module.warn(msg)
+                        log(msg)
                         self.module_result["changed"] = False
                         self.module.exit_json(**self.module_result)
                     else:
                         self.module_result["changed"] = True
-                        log(
-                            "INFO: Resource %s:%s exists. Will be UPDATED after omitting the immutable keys."
-                            % (
-                                self.resource_name,
-                                self.resource_id,
-                            )
+                        msg = (
+                            f"Resource {self.resource_name}/{self.resource_id} is updated after ignoring following "
+                            f"non-updatable keys: {immutable_keys_list}"
                         )
+                        self.module.warn(msg)
+                        log(msg)
                         ok, err = update_resource(
                             self.client, self.resource_name, self.resource_module_params
                         )

--- a/plugins/module_utils/module_executor.py
+++ b/plugins/module_utils/module_executor.py
@@ -469,7 +469,7 @@ class ModuleExecutor(object):
                         self.resource_module_params.pop(key)
 
                     is_identical, temp_immutable_list = self.is_resource_identical()
-                    #temp_immutable_list is a dummy as '_' is not allowed in lint.
+                    # temp_immutable_list is a dummy as '_' is not allowed in lint.
                     if is_identical:
                         msg = (
                             f"Resource {self.resource_name}/{self.resource_id} not updated because user is trying to "

--- a/plugins/module_utils/module_executor.py
+++ b/plugins/module_utils/module_executor.py
@@ -441,7 +441,19 @@ class ModuleExecutor(object):
                     )
                 )
             else:
-                if msg is None:
+                self.module_result["changed"] = True
+                if self.resource_name.endswith("_binding"):
+                    # Generally bindings are not updated. They are removed and added again.
+                    log(
+                        "INFO: Resource %s:%s exists and is different. Will be REMOVED and ADDED."
+                        % (self.resource_name, self.resource_id)
+                    )
+                    self.delete()
+                    ok, err = create_resource(
+                        self.client, self.resource_name, self.resource_module_params
+                    )
+
+                elif msg is None:
                     self.module_result["changed"] = True
                     log(
                         "INFO: Resource %s:%s exists and is different. Will be UPDATED."
@@ -461,11 +473,11 @@ class ModuleExecutor(object):
                         self.resource_module_params.pop(key)
 
                     is_identical, msg1 = self.is_resource_identical()
-                    
+
                     if is_identical and msg1 is None:
                         self.module.warn(f"DEBUG: Resource not updated because - {msg}")
                         self.module_result["changed"] = False
-                        self.module.exit_json(**self.module_result) 
+                        self.module.exit_json(**self.module_result)
                     else:
                         self.module_result["changed"] = True
                         log(

--- a/plugins/module_utils/module_executor.py
+++ b/plugins/module_utils/module_executor.py
@@ -468,8 +468,8 @@ class ModuleExecutor(object):
                     for key in immutable_keys_list:
                         self.resource_module_params.pop(key)
 
-                    is_identical, _ = self.is_resource_identical()
-
+                    is_identical, temp_immutable_list = self.is_resource_identical()
+                    #temp_immutable_list is a dummy as '_' is not allowed in lint.
                     if is_identical:
                         msg = (
                             f"Resource {self.resource_name}/{self.resource_id} not updated because user is trying to "


### PR DESCRIPTION
The user has run a playbook where the user tries to update some non-updatable parameters in an entity. Previously an error was thrown in such cases.

Now Instead, a warning was thrown and changed = False to handle the given case gracefully. 

ubuntu@ubuntu:~/workspace/ansible-collection-netscaleradc$ ansible-playbook examples/lbvserver.yaml 
[WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'

PLAY [Sample lbvserver playbook] **********************************************************************************************************************************************************************************************************************************

TASK [Configure lbvserver] ****************************************************************************************************************************************************************************************************************************************
[WARNING]: Resource lbvserver/lb_dns_01 not updated because user is trying to update following non-updatable keys: ['port']
ok: [localhost]

PLAY RECAP ********************************************************************************************************************************************************************************************************************************************************
localhost                  : ok=1    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   





ubuntu@ubuntu:~/workspace/ansible-collection-netscaleradc$ ansible-playbook examples/lbvserver.yaml 
[WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'

PLAY [Sample lbvserver playbook] **********************************************************************************************************************************************************************************************************************************

TASK [Configure lbvserver] ****************************************************************************************************************************************************************************************************************************************
[WARNING]: Resource lbvserver/lb_dns_01 is updated after ignoring following non-updatable keys: ['port']
changed: [localhost]

PLAY RECAP ********************************************************************************************************************************************************************************************************************************************************
localhost                  : ok=1    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   


