### PR TITLE
Removing Basic auth in ansible collections netscaler adc

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -13,15 +13,15 @@ readme: README.md
 # A list of the collection's content authors. Can be just the name or in the format 'Full Name <email> (url)
 # @nicks:irc/im.site#channel'
 authors:
-- Sumanth Lingappa <sumanth.lingappa@cloud.com>
-- Shiva Shankar Vaddepally <shivashankar.vaddepally@cloud.com>
+  - Sumanth Lingappa <sumanth.lingappa@cloud.com>
+  - Shiva Shankar Vaddepally <shivashankar.vaddepally@cloud.com>
 ### OPTIONAL but strongly recommended
 # A short summary description of the collection
 description: Ansible Collection Modules for NetScaler ADC
 # Either a single license or a list of licenses for content inside of a collection. Ansible Galaxy currently only
 # accepts L(SPDX,https://spdx.org/licenses/) licenses. This key is mutually exclusive with 'license_file'
 license:
-- MIT
+  - MIT
 # The path to the license file for the collection. This path is relative to the root of the collection. This key is
 # mutually exclusive with 'license'
 # license_file: '' # TODO
@@ -29,9 +29,9 @@ license:
 # A list of tags you want to associate with the collection for indexing/searching. A tag name has the same character
 # requirements as 'namespace' and 'name'
 tags:
-- netscaler
-- adc
-- networking
+  - netscaler
+  - adc
+  - networking
 # Collections that this collection requires to be installed for it to be usable. The key of the dict is the
 # collection label 'namespace.name'. The value is a version range
 # L(specifiers,https://python-semanticversion.readthedocs.io/en/latest/#requirement-specification). Multiple version
@@ -50,18 +50,18 @@ issues: https://github.com/netscaler/ansible-collection-netscaleradc/issues
 # uses 'fnmatch' to match the files or directories. Some directories and files like 'galaxy.yml', '*.pyc', '*.retry',
 # and '.git' are always filtered. Mutually exclusive with 'manifest'
 build_ignore:
-# https://docs.ansible.com/ansible/latest/dev_guide/developing_collections_distributing.html#ignoring-files-and-folders
-- "_built_docs*"
-- ".github*"
-- ".vscode*"
-- "assets*"
-- .DS_Store
-- docs
-- examples
-- tools
-- issues
-- "**/netscaler-adc-*.tar.gz"
-- Makefile
+  # https://docs.ansible.com/ansible/latest/dev_guide/developing_collections_distributing.html#ignoring-files-and-folders
+  - "_built_docs*"
+  - ".github*"
+  - ".vscode*"
+  - "assets*"
+  - ".DS_Store"
+  - "docs"
+  - "examples"
+  - "tools"
+  - "issues"
+  - "**/netscaler-adc-*.tar.gz"
+  - "Makefile"
 
 # A dict controlling use of manifest directives used in building the collection artifact. The key 'directives' is a
 # list of MANIFEST.in style

--- a/plugins/module_utils/module_executor.py
+++ b/plugins/module_utils/module_executor.py
@@ -142,7 +142,7 @@ class ModuleExecutor(object):
             self.module.params.get("nitro_user"),
             self.module.params.get("nitro_pass")
         ])
-        if have_pass:
+        if have_pass and not self.module.check_mode:
             self.client._headers.pop("X-NITRO-USER", None)
             self.client._headers.pop("X-NITRO-PASS", None)
             self.client._headers.pop("Cookie", None)
@@ -160,13 +160,13 @@ class ModuleExecutor(object):
                     self.module.params["nitro_auth_token"] = response["login"][0].get("sessionid", None)
                 else:
                     self.module.params["nitro_auth_token"] = response.get("sessionid", None)
-                
+
                 if not self.module.params["nitro_auth_token"]:
                     self.return_failure("ERROR: Login failed. No sessionid returned from the NetScaler ADC")
                 log("INFO: Login successful. Session ID: %s" % self.module.params["nitro_auth_token"])
-                
+
                 self.client._headers["Cookie"] = (
-                "NITRO_AUTH_TOKEN=%s" % self.module.params["nitro_auth_token"]
+                    "NITRO_AUTH_TOKEN=%s" % self.module.params["nitro_auth_token"]
                 )
 
         self.ns_major_version, self.ns_minor_version = get_netscaler_version(

--- a/plugins/module_utils/module_executor.py
+++ b/plugins/module_utils/module_executor.py
@@ -212,12 +212,13 @@ class ModuleExecutor(object):
             # }
         if self.resource_name == "login":
             self.module_result["sessionid"] = self.sessionid
-        if self.client._headers["Cookie"] != "":
+        if self.client._headers.get("Cookie", None) not in (None, "") and not self.module.check_mode:
             ok, response = adc_logout(self.client)
             if not ok:
                 log("ERROR: Logout failed: %s" % response)
             else:
                 log("INFO: Logout successful")
+                self.client._headers["Cookie"] = ""
         self.module.exit_json(**self.module_result)
 
     @trace
@@ -241,7 +242,7 @@ class ModuleExecutor(object):
 
     @trace
     def return_failure(self, msg):
-        if self.client._headers["Cookie"] != "":
+        if self.client._headers["Cookie"] != "" and not self.module.check_mode:
             ok, response = adc_logout(self.client)
             if not ok:
                 log("ERROR: Logout failed: %s" % response)

--- a/plugins/module_utils/module_executor.py
+++ b/plugins/module_utils/module_executor.py
@@ -138,11 +138,11 @@ class ModuleExecutor(object):
             self.module.params["api_path"] = "nitro/v2/config"
 
         self.client = NitroAPIClient(self.module, self.resource_name)
-        have_pass = all([
+        have_userpass = all([
             self.module.params.get("nitro_user"),
             self.module.params.get("nitro_pass")
         ])
-        if have_pass and not self.module.check_mode:
+        if have_userpass and not self.module.check_mode:
             self.client._headers.pop("X-NITRO-USER", None)
             self.client._headers.pop("X-NITRO-PASS", None)
             self.client._headers.pop("Cookie", None)
@@ -212,6 +212,12 @@ class ModuleExecutor(object):
             # }
         if self.resource_name == "login":
             self.module_result["sessionid"] = self.sessionid
+        if self.client._headers["Cookie"] != "":
+            ok, response = adc_logout(self.client)
+            if not ok:
+                log("ERROR: Logout failed: %s" % response)
+            else:
+                log("INFO: Logout successful")
         self.module.exit_json(**self.module_result)
 
     @trace
@@ -241,6 +247,7 @@ class ModuleExecutor(object):
                 log("ERROR: Logout failed: %s" % response)
             else:
                 log("INFO: Logout successful")
+                self.client._headers["Cookie"] = ""
         self.module.fail_json(msg=msg, **self.module_result)
 
     @trace

--- a/plugins/module_utils/module_executor.py
+++ b/plugins/module_utils/module_executor.py
@@ -138,6 +138,37 @@ class ModuleExecutor(object):
             self.module.params["api_path"] = "nitro/v2/config"
 
         self.client = NitroAPIClient(self.module, self.resource_name)
+        have_pass = all([
+            self.module.params.get("nitro_user"),
+            self.module.params.get("nitro_pass")
+        ])
+        if have_pass:
+            self.client._headers.pop("X-NITRO-USER", None)
+            self.client._headers.pop("X-NITRO-PASS", None)
+            self.client._headers.pop("Cookie", None)
+            ok, response = adc_login(
+                self.client,
+                self.module.params["nitro_user"],
+                self.module.params["nitro_pass"],
+            )
+            if not ok:
+                self.client._headers["Cookie"] = ""
+                self.return_failure("ERROR: Login failed: %s" % response)
+
+            else:
+                if self.netscaler_console_as_proxy_server:
+                    self.module.params["nitro_auth_token"] = response["login"][0].get("sessionid", None)
+                else:
+                    self.module.params["nitro_auth_token"] = response.get("sessionid", None)
+                
+                if not self.module.params["nitro_auth_token"]:
+                    self.return_failure("ERROR: Login failed. No sessionid returned from the NetScaler ADC")
+                log("INFO: Login successful. Session ID: %s" % self.module.params["nitro_auth_token"])
+                
+                self.client._headers["Cookie"] = (
+                "NITRO_AUTH_TOKEN=%s" % self.module.params["nitro_auth_token"]
+                )
+
         self.ns_major_version, self.ns_minor_version = get_netscaler_version(
             self.client
         )
@@ -204,6 +235,12 @@ class ModuleExecutor(object):
 
     @trace
     def return_failure(self, msg):
+        if self.client._headers["Cookie"] != "":
+            ok, response = adc_logout(self.client)
+            if not ok:
+                log("ERROR: Logout failed: %s" % response)
+            else:
+                log("INFO: Logout successful")
         self.module.fail_json(msg=msg, **self.module_result)
 
     @trace


### PR DESCRIPTION
Based on the security issues reported by the team, it has been decided to remove basic auth while firing the Nitro API. 
The initial idea was to log in at the 1st task and pass it to the next tasks implicitly, but not possible in Ansible. So, this change login for every task and use the retrieved sessionid for that task and logout after every task.